### PR TITLE
Extract mistral client and mistral tokenizer to separate files

### DIFF
--- a/lib/mistral_ai_book_search_example/book_search.dart
+++ b/lib/mistral_ai_book_search_example/book_search.dart
@@ -4,7 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:mistral_ai_chat_example_app/mistral_ai_book_search_example/algebra.dart';
 import 'package:mistral_ai_chat_example_app/mistral_ai_book_search_example/models.dart';
-import 'package:mistral_ai_chat_example_app/mistral_ai_chat_example/mistral_client.dart';
+import 'package:mistral_ai_chat_example_app/mistral_client/mistral_client.dart';
 import 'package:mistral_ai_chat_example_app/mistral_tokenizer/mistral_tokenizer.dart';
 import 'package:mistralai_client_dart/mistralai_client_dart.dart';
 

--- a/lib/mistral_ai_book_search_example/mistralai_book_search_page.dart
+++ b/lib/mistral_ai_book_search_example/mistralai_book_search_page.dart
@@ -1,11 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:mistral_ai_chat_example_app/mistral_ai_book_search_example/book_search.dart';
 import 'package:mistral_ai_chat_example_app/mistral_ai_book_search_example/models.dart';
-import 'package:mistral_ai_chat_example_app/mistral_ai_chat_example/mistral_client.dart';
+import 'package:mistral_ai_chat_example_app/mistral_client/mistral_client.dart';
 import 'package:mistral_ai_chat_example_app/mistral_tokenizer/mistral_tokenizer.dart';
 import 'package:provider/provider.dart';
-
-final mistralTokenizer = MistralTokenizer.fromBase64();
 
 class MistralAIBookSearchPage extends StatelessWidget {
   const MistralAIBookSearchPage({super.key});

--- a/lib/mistral_ai_book_search_example/prepare_data.dart
+++ b/lib/mistral_ai_book_search_example/prepare_data.dart
@@ -6,17 +6,25 @@ import 'package:mistral_ai_chat_example_app/mistral_ai_book_search_example/model
 import 'package:mistral_ai_chat_example_app/mistral_tokenizer/mistral_tokenizer.dart';
 import 'package:mistralai_client_dart/mistralai_client_dart.dart';
 
+// tokenizer and client are here to be sure the script
+// can be used as a standalone script
+
 final mistralTokenizer = MistralTokenizer.fromBase64();
 
 const String mistralAIApiKey = String.fromEnvironment('MISTRAL_AI_API_KEY');
 
 final mistralAIClient = MistralAIClient(apiKey: mistralAIApiKey);
 
-// use this command to run this file from the root of the project:
+// This file is supposed to be run from the root of the project
+// to generate data for book search example.
+//
+// Do not use this file in the app.
+//
+// Use this command to run this file from the root of the project:
 // dart run --define=MISTRAL_AI_API_KEY=YourAPIKey lib/mistral_ai_book_search_example/prepare_data.dart
-// 
-// to generate data for different book, change the fileName variable
-// and put the text file in assets folder
+//
+// To generate data for different book, change the fileName variable
+// and put the text file in assets folder.
 void main() async {
   final mainStopWatch = Stopwatch()..start();
   const fileName = '20k_leages_under_the_sea_verne';

--- a/lib/mistral_ai_chat_example/mistralai_chat_page.dart
+++ b/lib/mistral_ai_chat_example/mistralai_chat_page.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:collection';
 
 import 'package:flutter/material.dart';
-import 'package:mistral_ai_chat_example_app/mistral_ai_chat_example/mistral_client.dart';
+import 'package:mistral_ai_chat_example_app/mistral_client/mistral_client.dart';
 import 'package:mistralai_client_dart/mistralai_client_dart.dart';
 import 'package:provider/provider.dart';
 

--- a/lib/mistral_ai_llm_controller_example/mistral_ai_llm_controller_page.dart
+++ b/lib/mistral_ai_llm_controller_example/mistral_ai_llm_controller_page.dart
@@ -5,7 +5,7 @@ import 'package:mistral_ai_chat_example_app/mistral_ai_llm_controller_example/lo
 import 'package:mistral_ai_chat_example_app/mistral_ai_llm_controller_example/model.dart';
 import 'package:mistral_ai_chat_example_app/mistral_ai_llm_controller_example/prompt.dart';
 import 'package:mistral_ai_chat_example_app/mistral_ai_llm_controller_example/utils.dart';
-import 'package:mistral_ai_chat_example_app/mistral_ai_summary_example/mistral_client.dart';
+import 'package:mistral_ai_chat_example_app/mistral_client/mistral_client.dart';
 import 'package:mistralai_client_dart/mistralai_client_dart.dart';
 
 class MistralAILlmControllerPage extends StatefulWidget {

--- a/lib/mistral_ai_summary_example/mistral_client.dart
+++ b/lib/mistral_ai_summary_example/mistral_client.dart
@@ -1,5 +1,0 @@
-import 'package:mistralai_client_dart/mistralai_client_dart.dart';
-
-const String mistralAIApiKey = String.fromEnvironment('MISTRAL_AI_API_KEY');
-
-final mistralAIClient = MistralAIClient(apiKey: mistralAIApiKey);

--- a/lib/mistral_ai_summary_example/mistralai_summary_page.dart
+++ b/lib/mistral_ai_summary_example/mistralai_summary_page.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:mistral_ai_chat_example_app/mistral_ai_summary_example/mistral_client.dart';
 import 'package:mistral_ai_chat_example_app/mistral_ai_summary_example/model.dart';
 import 'package:mistral_ai_chat_example_app/mistral_ai_summary_example/summary_settings_page.dart';
 import 'package:mistral_ai_chat_example_app/mistral_ai_summary_example/utils.dart';
+import 'package:mistral_ai_chat_example_app/mistral_client/mistral_client.dart';
 import 'package:mistralai_client_dart/mistralai_client_dart.dart';
 
 class MistralAISummaryPage extends StatefulWidget {

--- a/lib/mistral_client/mistral_client.dart
+++ b/lib/mistral_client/mistral_client.dart
@@ -2,4 +2,6 @@ import 'package:mistralai_client_dart/mistralai_client_dart.dart';
 
 const String mistralAIApiKey = String.fromEnvironment('MISTRAL_AI_API_KEY');
 
+// MistralAI client instance to use in app
+// across multiple examples
 final mistralAIClient = MistralAIClient(apiKey: mistralAIApiKey);


### PR DESCRIPTION
What's changed:
- all classes/functions that were using mistral client and tokenizer are now using the same instance of those
  - exception is `prepare_data.dart` where we intentionally want to have a separate client and tokenizer instance.
- additionally add a little bit more explanation to `prepare_data.dart` script

Resolves #12 