### PR TITLE
Add setting header to bottom sheet in chat example

### DIFF
--- a/lib/mistral_ai_chat_example/mistralai_chat_page.dart
+++ b/lib/mistral_ai_chat_example/mistralai_chat_page.dart
@@ -67,12 +67,19 @@ class _ChatSettingsButton extends StatelessWidget {
       builder: (context) {
         return ChangeNotifierProvider.value(
           value: chatModel,
-          child: const SizedBox(
+          child: SizedBox(
             height: 200,
             child: Column(
               children: [
-                SizedBox(height: 8),
-                _StreamingModeSwitch(),
+                Padding(
+                  padding: const EdgeInsets.only(left: 16, right: 16, top: 20),
+                  child: Text(
+                    'Settings',
+                    style: Theme.of(context).textTheme.titleLarge,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                const _StreamingModeSwitch(),
               ],
             ),
           ),


### PR DESCRIPTION
- add bottom sheet header with `Settings` text

![image](https://github.com/nomtek/flutter_ai_examples/assets/2642942/b49774e5-c446-4a53-8f4f-22695dded7af)
