### PR TITLE
App settings page

### DIFF
--- a/devtools_options.yaml
+++ b/devtools_options.yaml
@@ -1,0 +1,1 @@
+extensions:

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -1,16 +1,36 @@
 import 'package:flutter/material.dart';
+import 'package:mistral_ai_chat_example_app/app/app_settings/app_settings.dart';
 import 'package:mistral_ai_chat_example_app/app/router.dart';
 import 'package:mistral_ai_chat_example_app/app/theme.dart';
+import 'package:mistralai_client_dart/mistralai_client_dart.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+  const MyApp({required this.sharedPreferences, super.key});
+
+  final SharedPreferences sharedPreferences;
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp.router(
-      debugShowCheckedModeBanner: false,
-      routerConfig: router,
-      theme: lightTheme(),
+    return MultiProvider(
+      providers: [
+        Provider<SharedPreferences>.value(value: sharedPreferences),
+        ChangeNotifierProvider<AppSettings>(
+          create: (context) =>
+              AppSettings(context.read<SharedPreferences>())..init(),
+        ),
+        ProxyProvider0(
+          update: (context, __) => MistralAIClient(
+            apiKey: context.watch<AppSettings>().mistralApiKey,
+          ),
+        ),
+      ],
+      child: MaterialApp.router(
+        debugShowCheckedModeBanner: false,
+        routerConfig: router,
+        theme: lightTheme(),
+      ),
     );
   }
 }

--- a/lib/app/app_settings/app_settings.dart
+++ b/lib/app/app_settings/app_settings.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
-import 'package:mistral_ai_chat_example_app/mistral_client/mistral_client.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 // key for the shared preferences where the API key is stored
 const _sharedPrefsMistralApiKey = 'mistralApiKey';
+
+// environment variable for the Mistral AI API key
+const String _mistralAIApiKeyEnvVar =
+    String.fromEnvironment('MISTRAL_AI_API_KEY');
 
 class AppSettings extends ValueNotifier<AppSettingsData> {
   AppSettings(this._sharedPreferences)
@@ -22,7 +25,10 @@ class AppSettings extends ValueNotifier<AppSettingsData> {
     if (!_sharedPreferences.containsKey(_sharedPrefsMistralApiKey)) {
       // if there is no persisted API key,
       // try to set the environment variable one as a fallback
-      _sharedPreferences.setString(_sharedPrefsMistralApiKey, mistralAIApiKey);
+      _sharedPreferences.setString(
+        _sharedPrefsMistralApiKey,
+        _mistralAIApiKeyEnvVar,
+      );
     }
     mistralApiKey =
         _sharedPreferences.getString(_sharedPrefsMistralApiKey) ?? '';

--- a/lib/app/app_settings/app_settings.dart
+++ b/lib/app/app_settings/app_settings.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:mistral_ai_chat_example_app/mistral_client/mistral_client.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+// key for the shared preferences where the API key is stored
+const _sharedPrefsMistralApiKey = 'mistralApiKey';
+
+class AppSettings extends ValueNotifier<AppSettingsData> {
+  AppSettings(this._sharedPreferences)
+      : super(const AppSettingsData(mistralApiKey: ''));
+
+  final SharedPreferences _sharedPreferences;
+
+  String get mistralApiKey => value.mistralApiKey;
+
+  set mistralApiKey(String apiKey) {
+    value = value.copyWith(apiKey: apiKey);
+  }
+
+  // initialize the app settings from the shared preferences
+  void init() {
+    if (!_sharedPreferences.containsKey(_sharedPrefsMistralApiKey)) {
+      // if there is no persisted API key,
+      // try to set the environment variable one as a fallback
+      _sharedPreferences.setString(_sharedPrefsMistralApiKey, mistralAIApiKey);
+    }
+    mistralApiKey =
+        _sharedPreferences.getString(_sharedPrefsMistralApiKey) ?? '';
+  }
+}
+
+@immutable
+class AppSettingsData {
+  const AppSettingsData({
+    required this.mistralApiKey,
+  });
+
+  final String mistralApiKey;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is AppSettingsData && other.mistralApiKey == mistralApiKey;
+  }
+
+  @override
+  int get hashCode => mistralApiKey.hashCode;
+
+  AppSettingsData copyWith({
+    String? apiKey,
+  }) {
+    return AppSettingsData(
+      mistralApiKey: apiKey ?? mistralApiKey,
+    );
+  }
+}

--- a/lib/app/app_settings/app_settings_page.dart
+++ b/lib/app/app_settings/app_settings_page.dart
@@ -71,7 +71,7 @@ class _MistralAIApiKeyFieldState extends State<MistralAIApiKeyField> {
         ),
         TextButton(
           onPressed: () => _save(context),
-          child: const Text('Save'),
+          child: const Text('Update'),
         ),
       ],
       title: const Text('Update Mistral AI API Key'),

--- a/lib/app/app_settings/app_settings_page.dart
+++ b/lib/app/app_settings/app_settings_page.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:mistral_ai_chat_example_app/app/app_settings/app_settings.dart';
+import 'package:provider/provider.dart';
+
+class AppSettingsPage extends StatelessWidget {
+  const AppSettingsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final mistralAIApiKey = context.watch<AppSettings>().mistralApiKey;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('App Settings'),
+      ),
+      body: SafeArea(
+        child: Column(
+          children: [
+            ListTile(
+              title: const Text('Mistral AI API Key'),
+              subtitle: Text('Current value: $mistralAIApiKey'),
+              onTap: () {
+                showDialog<void>(
+                  context: context,
+                  builder: (context) => MistralAIApiKeyField(
+                    currentApiKey: context.read<AppSettings>().mistralApiKey,
+                  ),
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class MistralAIApiKeyField extends StatefulWidget {
+  const MistralAIApiKeyField({
+    required this.currentApiKey,
+    super.key,
+  });
+
+  final String currentApiKey;
+
+  @override
+  State<MistralAIApiKeyField> createState() => _MistralAIApiKeyFieldState();
+}
+
+class _MistralAIApiKeyFieldState extends State<MistralAIApiKeyField> {
+  late final TextEditingController inputController;
+
+  @override
+  void initState() {
+    inputController = TextEditingController(text: widget.currentApiKey);
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    inputController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
+        TextButton(
+          onPressed: () => _save(context),
+          child: const Text('Save'),
+        ),
+      ],
+      title: const Text('Update Mistral AI API Key'),
+      content: TextField(
+        decoration: const InputDecoration(
+          labelText: 'API Key',
+          border: OutlineInputBorder(),
+        ),
+        controller: inputController,
+        autofocus: true,
+        onSubmitted: (_) => _save(context),
+      ),
+    );
+  }
+
+  void _save(BuildContext context) {
+    context.read<AppSettings>().mistralApiKey = inputController.text;
+    Navigator.pop(context);
+  }
+}

--- a/lib/app/app_settings/app_settings_page.dart
+++ b/lib/app/app_settings/app_settings_page.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/material_symbols_icons.dart';
 import 'package:mistral_ai_chat_example_app/app/app_settings/app_settings.dart';
+import 'package:mistral_ai_chat_example_app/app/theme.dart';
 import 'package:provider/provider.dart';
 
 class AppSettingsPage extends StatelessWidget {
@@ -8,26 +10,31 @@ class AppSettingsPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final mistralAIApiKey = context.watch<AppSettings>().mistralApiKey;
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('App Settings'),
-      ),
-      body: SafeArea(
-        child: Column(
-          children: [
-            ListTile(
-              title: const Text('Mistral AI API Key'),
-              subtitle: Text('Current value: $mistralAIApiKey'),
-              onTap: () {
-                showDialog<void>(
-                  context: context,
-                  builder: (context) => MistralAIApiKeyField(
-                    currentApiKey: context.read<AppSettings>().mistralApiKey,
-                  ),
-                );
-              },
-            ),
-          ],
+
+    return DarkerBackgroundTheme(
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('App Settings'),
+        ),
+        body: SafeArea(
+          child: Column(
+            children: [
+              ListTile(
+                leading: const Icon(Symbols.key_vertical),
+                titleAlignment: ListTileTitleAlignment.titleHeight,
+                title: const Text('Mistral AI API Key'),
+                subtitle: Text('Current value: $mistralAIApiKey'),
+                onTap: () {
+                  showDialog<void>(
+                    context: context,
+                    builder: (context) => MistralAIApiKeyField(
+                      currentApiKey: context.read<AppSettings>().mistralApiKey,
+                    ),
+                  );
+                },
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/app/home_page.dart
+++ b/lib/app/home_page.dart
@@ -1,11 +1,21 @@
 import 'package:flutter/material.dart';
 import 'package:mistral_ai_chat_example_app/app/home_tiles.dart';
+import 'package:mistral_ai_chat_example_app/app/router.dart';
 
 class HomePage extends StatelessWidget {
   const HomePage({super.key});
   @override
-  Widget build(BuildContext context) => const Scaffold(
-        body: SafeArea(
+  Widget build(BuildContext context) => Scaffold(
+        appBar: AppBar(
+          title: const Text('Fluter AI Examples'),
+          actions: [
+            IconButton(
+              onPressed: () => const AppSettingsRoute().go(context),
+              icon: const Icon(Icons.settings),
+            ),
+          ],
+        ),
+        body: const SafeArea(
           child: SingleChildScrollView(
             padding: EdgeInsets.all(20),
             child: Column(

--- a/lib/app/home_page.dart
+++ b/lib/app/home_page.dart
@@ -7,7 +7,7 @@ class HomePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) => Scaffold(
         appBar: AppBar(
-          title: const Text('Fluter AI Examples'),
+          title: const Text('Flutter AI Examples'),
           actions: [
             IconButton(
               onPressed: () => const AppSettingsRoute().go(context),

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:mistral_ai_chat_example_app/app/app_settings/app_settings_page.dart';
 import 'package:mistral_ai_chat_example_app/app/home_page.dart';
 import 'package:mistral_ai_chat_example_app/mistral_ai_book_search_example/mistralai_book_search_page.dart';
 import 'package:mistral_ai_chat_example_app/mistral_ai_chat_example/mistralai_chat_page.dart';
@@ -13,6 +14,7 @@ final router = GoRouter(routes: $appRoutes);
 @TypedGoRoute<HomeRoute>(
   path: '/',
   routes: [
+    TypedGoRoute<AppSettingsRoute>(path: 'app-settings'),
     TypedGoRoute<MistralAIChatRoute>(path: 'mistralai-chat'),
     TypedGoRoute<MistralAISummaryRoute>(path: 'mistralai-summary'),
     TypedGoRoute<MistralAILlmControllerRoute>(path: 'mistralai-llm-controller'),
@@ -24,6 +26,15 @@ class HomeRoute extends GoRouteData {
 
   @override
   Widget build(BuildContext context, GoRouterState state) => const HomePage();
+}
+
+class AppSettingsRoute extends GoRouteData {
+  const AppSettingsRoute();
+
+  @override
+  Page<void> buildPage(BuildContext context, GoRouterState state) {
+    return _buildPage(const AppSettingsPage());
+  }
 }
 
 class MistralAIChatRoute extends GoRouteData {

--- a/lib/app/router.g.dart
+++ b/lib/app/router.g.dart
@@ -15,6 +15,10 @@ RouteBase get $homeRoute => GoRouteData.$route(
       factory: $HomeRouteExtension._fromState,
       routes: [
         GoRouteData.$route(
+          path: 'app-settings',
+          factory: $AppSettingsRouteExtension._fromState,
+        ),
+        GoRouteData.$route(
           path: 'mistralai-chat',
           factory: $MistralAIChatRouteExtension._fromState,
         ),
@@ -38,6 +42,24 @@ extension $HomeRouteExtension on HomeRoute {
 
   String get location => GoRouteData.$location(
         '/',
+      );
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+extension $AppSettingsRouteExtension on AppSettingsRoute {
+  static AppSettingsRoute _fromState(GoRouterState state) =>
+      const AppSettingsRoute();
+
+  String get location => GoRouteData.$location(
+        '/app-settings',
       );
 
   void go(BuildContext context) => context.go(location);

--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -7,3 +7,39 @@ ThemeData lightTheme() {
     textTheme: GoogleFonts.interTextTheme(baseTheme.textTheme),
   );
 }
+
+/// Theme with a darker background color.
+//
+// This theme is not fully complete for all the components.
+class DarkerBackgroundTheme extends StatelessWidget {
+  const DarkerBackgroundTheme({required this.child, super.key});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    // This theme is not fully complete.
+    // There are updates to the components that are used
+    // in the current examples.
+    // If any component is not looking good then update it here
+    final baseTheme = Theme.of(context);
+    final darkBackgroundThemeData = ThemeData.from(
+      colorScheme: baseTheme.colorScheme.copyWith(
+        // change the background color to a darker color for all widgets
+        // using this color
+        background: baseTheme.colorScheme.surfaceVariant,
+      ),
+      textTheme: baseTheme.textTheme,
+    ).copyWith(
+      // updates to the components theme to better work with the new
+      // background color
+      appBarTheme: baseTheme.appBarTheme.copyWith(
+        backgroundColor: baseTheme.colorScheme.surfaceVariant,
+      ),
+      listTileTheme: baseTheme.listTileTheme.copyWith(
+        tileColor: baseTheme.colorScheme.surface,
+      ),
+    );
+    return Theme(data: darkBackgroundThemeData, child: child);
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,13 +2,19 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:mistral_ai_chat_example_app/app/app.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
-void main() {
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
   LicenseRegistry.addLicense(() async* {
     // register the license for the Google Fonts
     final license = await rootBundle.loadString('google_fonts/OFL.txt');
     yield LicenseEntryWithLineBreaks(['google_fonts'], license);
   });
 
-  runApp(const MyApp());
+  final sharedPreferences = await SharedPreferences.getInstance();
+
+  runApp(
+    MyApp(sharedPreferences: sharedPreferences),
+  );
 }

--- a/lib/mistral_ai_book_search_example/book_search.dart
+++ b/lib/mistral_ai_book_search_example/book_search.dart
@@ -4,7 +4,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:mistral_ai_chat_example_app/mistral_ai_book_search_example/algebra.dart';
 import 'package:mistral_ai_chat_example_app/mistral_ai_book_search_example/models.dart';
-import 'package:mistral_ai_chat_example_app/mistral_client/mistral_client.dart';
 import 'package:mistral_ai_chat_example_app/mistral_tokenizer/mistral_tokenizer.dart';
 import 'package:mistralai_client_dart/mistralai_client_dart.dart';
 
@@ -12,13 +11,13 @@ import 'package:mistralai_client_dart/mistralai_client_dart.dart';
 // and provides methods to find answers to questions
 class BookSearch {
   BookSearch({
-    required this.client,
+    required this.mistralAIClient,
     required this.tokenizer,
     this.bookTitle = 'Twenty Thousands Leagues Under the Sea',
     this.bookSearchDataAssetPath = 'assets/20k_leages_under_the_sea_verne.json',
   });
 
-  final MistralAIClient client;
+  final MistralAIClient mistralAIClient;
   final MistralTokenizer tokenizer;
   late SearchData _searchData;
   bool _init = false;

--- a/lib/mistral_ai_book_search_example/mistralai_book_search_page.dart
+++ b/lib/mistral_ai_book_search_example/mistralai_book_search_page.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:mistral_ai_chat_example_app/mistral_ai_book_search_example/book_search.dart';
 import 'package:mistral_ai_chat_example_app/mistral_ai_book_search_example/models.dart';
-import 'package:mistral_ai_chat_example_app/mistral_client/mistral_client.dart';
 import 'package:mistral_ai_chat_example_app/mistral_tokenizer/mistral_tokenizer.dart';
 import 'package:provider/provider.dart';
 
@@ -10,9 +9,9 @@ class MistralAIBookSearchPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Provider(
-      create: (_) => BookSearch(
-        client: mistralAIClient,
+    return ProxyProvider0(
+      update: (context, __) => BookSearch(
+        mistralAIClient: context.watch(),
         tokenizer: mistralTokenizer,
       ),
       child: const _Body(),

--- a/lib/mistral_ai_chat_example/mistralai_chat_page.dart
+++ b/lib/mistral_ai_chat_example/mistralai_chat_page.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:collection';
 
 import 'package:flutter/material.dart';
-import 'package:mistral_ai_chat_example_app/mistral_client/mistral_client.dart';
 import 'package:mistralai_client_dart/mistralai_client_dart.dart';
 import 'package:provider/provider.dart';
 
@@ -15,7 +14,7 @@ class MistralAIChatPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return SelectionArea(
       child: ChangeNotifierProvider(
-        create: (context) => _ChatModel(mistralAIClient),
+        create: (context) => _ChatModel(context.read()),
         child: Scaffold(
           appBar: AppBar(
             title: const Text('MistralAI Chat'),

--- a/lib/mistral_ai_llm_controller_example/mistral_ai_llm_controller_page.dart
+++ b/lib/mistral_ai_llm_controller_example/mistral_ai_llm_controller_page.dart
@@ -5,8 +5,8 @@ import 'package:mistral_ai_chat_example_app/mistral_ai_llm_controller_example/lo
 import 'package:mistral_ai_chat_example_app/mistral_ai_llm_controller_example/model.dart';
 import 'package:mistral_ai_chat_example_app/mistral_ai_llm_controller_example/prompt.dart';
 import 'package:mistral_ai_chat_example_app/mistral_ai_llm_controller_example/utils.dart';
-import 'package:mistral_ai_chat_example_app/mistral_client/mistral_client.dart';
 import 'package:mistralai_client_dart/mistralai_client_dart.dart';
+import 'package:provider/provider.dart';
 
 class MistralAILlmControllerPage extends StatefulWidget {
   const MistralAILlmControllerPage({super.key});
@@ -41,28 +41,31 @@ class _MistralAiLlmControllerPageState
     });
   }
 
-  Future<String> _getResponseFromAI(String command) async {
+  Future<String> _getResponseFromAI(
+    BuildContext context,
+    String command,
+  ) async {
     setState(() {
       showLoading = true;
       _log(commandMessage(command, controllerSettings));
     });
 
-    final response = await mistralAIClient.chat(
-      ChatParams(
-        model: 'mistral-medium',
-        messages: [
-          ChatMessage(role: 'system', content: controllerDescription),
-          ChatMessage(
-            role: 'system',
-            content: controllerContext(
-              availableFunctions,
-              controllerSettings,
-            ),
+    final response = await context.read<MistralAIClient>().chat(
+          ChatParams(
+            model: 'mistral-medium',
+            messages: [
+              ChatMessage(role: 'system', content: controllerDescription),
+              ChatMessage(
+                role: 'system',
+                content: controllerContext(
+                  availableFunctions,
+                  controllerSettings,
+                ),
+              ),
+              ChatMessage(role: 'user', content: command),
+            ],
           ),
-          ChatMessage(role: 'user', content: command),
-        ],
-      ),
-    );
+        );
 
     setState(() {
       showLoading = false;
@@ -108,13 +111,14 @@ class _MistralAiLlmControllerPageState
     }
   }
 
-  Future<void> _sendCommand() async {
+  Future<void> _sendCommand(BuildContext context) async {
     setState(() {
       _clearLogAndError();
       showLoading = true;
     });
     try {
       final commandResult = await _getResponseFromAI(
+        context,
         commandInputController.text,
       );
       _mapCommandResponseToUi(commandResult);
@@ -233,7 +237,7 @@ class _MistralAiLlmControllerPageState
                             )
                           : IconButton(
                               icon: const Icon(Icons.send),
-                              onPressed: _sendCommand,
+                              onPressed: () => _sendCommand(context),
                             ),
                     ),
                   ),

--- a/lib/mistral_ai_summary_example/mistralai_summary_page.dart
+++ b/lib/mistral_ai_summary_example/mistralai_summary_page.dart
@@ -3,8 +3,8 @@ import 'package:flutter/services.dart';
 import 'package:mistral_ai_chat_example_app/mistral_ai_summary_example/model.dart';
 import 'package:mistral_ai_chat_example_app/mistral_ai_summary_example/summary_settings_page.dart';
 import 'package:mistral_ai_chat_example_app/mistral_ai_summary_example/utils.dart';
-import 'package:mistral_ai_chat_example_app/mistral_client/mistral_client.dart';
 import 'package:mistralai_client_dart/mistralai_client_dart.dart';
+import 'package:provider/provider.dart';
 
 class MistralAISummaryPage extends StatefulWidget {
   const MistralAISummaryPage({super.key});
@@ -26,12 +26,12 @@ class _MistralAISummaryPageState extends State<MistralAISummaryPage> {
     super.dispose();
   }
 
-  Future<void> summarizeText(String text) async {
+  Future<void> summarizeText(BuildContext context, String text) async {
     setState(() {
       summaryResult = 'Loading...';
     });
     try {
-      final response = await mistralAIClient.chat(
+      final response = await context.read<MistralAIClient>().chat(
         ChatParams(
           model: 'mistral-medium',
           temperature: summarySettings.temperature,
@@ -98,7 +98,7 @@ class _MistralAISummaryPageState extends State<MistralAISummaryPage> {
                 children: [
                   ElevatedButton(
                     onPressed: () {
-                      summarizeText(summaryInputController.text);
+                      summarizeText(context, summaryInputController.text);
                     },
                     child: const Text('Summarize'),
                   ),
@@ -107,7 +107,7 @@ class _MistralAISummaryPageState extends State<MistralAISummaryPage> {
                     children: [
                       ElevatedButton(
                         onPressed: () {
-                          summarizeText(summaryTextSample);
+                          summarizeText(context, summaryTextSample);
                         },
                         child: const Text('Summarize sample tex'),
                       ),

--- a/lib/mistral_client/mistral_client.dart
+++ b/lib/mistral_client/mistral_client.dart
@@ -1,7 +1,0 @@
-import 'package:mistralai_client_dart/mistralai_client_dart.dart';
-
-const String mistralAIApiKey = String.fromEnvironment('MISTRAL_AI_API_KEY');
-
-// MistralAI client instance to use in app
-// across multiple examples
-final mistralAIClient = MistralAIClient(apiKey: mistralAIApiKey);

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,7 +6,9 @@ import FlutterMacOS
 import Foundation
 
 import path_provider_foundation
+import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -608,6 +608,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "81429e4481e1ccfb51ede496e916348668fd0921627779233bd24cc3ff6abd02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.2"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "8568a389334b6e83415b6aae55378e158fbc2314e074983362d20c562780fb06"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "7708d83064f38060c7b39db12aefe449cb8cdc031d6062280087bc4cdb988f5c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.5"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "9f2cbcf46d4270ea8be39fa156d86379077c8a5228d9dfdb1164ae0bb93f1faa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "22e2ecac9419b4246d7c22bfbbda589e3acf5c0351137d87dd2939d984d37c3b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: "7b15ffb9387ea3e237bb7a66b8a23d2147663d391cafc5c8f37b2e7b4bde5d21"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.2"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "841ad54f3c8381c480d0c9b508b89a34036f512482c407e6df7a9c4aa2ef8f59"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
   shelf:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   material_symbols_icons: ^4.2718.0
   mistralai_client_dart: 0.0.2
   provider: ^6.1.1
+  shared_preferences: ^2.2.2
   
 dev_dependencies:
   build_runner: ^2.4.8


### PR DESCRIPTION
App settings page where you can set settings relate to the whole app.

For now the only option to set there is Mistral AI API Key.

Changes:
- Page follows style of settings used in the new designs for Text summary example settings.
  - New widget DarkerBackgroundTheme for that
- By default the value in the settings will be read from `MISTRAL_AI_API_KEY` env var.
  - Value is persisted in shared preferences.
- Removed global mistral ai client 
  - now it's provided with Provider
  - all examples are using provided instance from context
  
Resolves #13

![image](https://github.com/nomtek/flutter_ai_examples/assets/2642942/7ae61dc7-03b8-408a-8e96-574e689afa34)
![image](https://github.com/nomtek/flutter_ai_examples/assets/2642942/e1ba1195-cba6-448e-84bf-aeb9acf4003a)

