### PR TITLE
Improve error handling in the example app

### DIFF
--- a/lib/app/app_settings/app_settings.dart
+++ b/lib/app/app_settings/app_settings.dart
@@ -43,6 +43,12 @@ class AppSettingsData {
 
   final String mistralApiKey;
 
+  // for now check if the API key is not empty
+  bool isMistralApiKeyValid() {
+    final isNotBlank = mistralApiKey.trim().isNotEmpty;
+    return isNotBlank;
+  }
+
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;

--- a/lib/app/app_settings/app_settings.dart
+++ b/lib/app/app_settings/app_settings.dart
@@ -44,10 +44,7 @@ class AppSettingsData {
   final String mistralApiKey;
 
   // for now check if the API key is not empty
-  bool isMistralApiKeyValid() {
-    final isNotBlank = mistralApiKey.trim().isNotEmpty;
-    return isNotBlank;
-  }
+bool isMistralApiKeyValid() => mistralApiKey.trim().isNotEmpty;
 
   @override
   bool operator ==(Object other) {

--- a/lib/app/home_page.dart
+++ b/lib/app/home_page.dart
@@ -1,8 +1,11 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_ai_examples/app/app_settings/app_settings.dart';
 import 'package:flutter_ai_examples/app/home_tiles.dart';
 import 'package:flutter_ai_examples/app/router.dart';
+import 'package:flutter_ai_examples/utils/snackbar_extension.dart';
 import 'package:provider/provider.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class HomePage extends StatelessWidget {
   const HomePage({super.key});
@@ -41,22 +44,70 @@ class MistralAIExamples extends StatelessWidget {
       children: [
         const HomeSectionTitle(sectionTitle: 'Mistral AI Examples'),
         const SizedBox(height: 16),
-        if (isMistralSetUp) const MistralExampleTilesGrid(),
-        if (!isMistralSetUp)
-          const Align(
-            alignment: Alignment.centerLeft,
-            child: Text(
-              'Please set up the Mistral AI API key in the app settings.',
-              style: TextStyle(fontSize: 20),
-            ),
-          ),
+        if (!isMistralSetUp) const MistralSetupNotFinished(),
+        const SizedBox(height: 16),
+        MistralExampleTilesGrid(isEnabled: isMistralSetUp),
       ],
     );
   }
 }
 
+class MistralSetupNotFinished extends StatelessWidget {
+  const MistralSetupNotFinished({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.red[100],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        children: [
+          Text.rich(
+            textAlign: TextAlign.center,
+            TextSpan(
+              text: 'Please setup Mistral AI API key.\n'
+                  'Without it, the examples will not work. \n'
+                  'You can get the API key from the ',
+              children: [
+                TextSpan(
+                  text: 'Mistral AI website.',
+                  style: TextStyle(
+                    color: Theme.of(context).primaryColor,
+                    decoration: TextDecoration.underline,
+                    decorationColor: Theme.of(context).primaryColor,
+                  ),
+                  recognizer: TapGestureRecognizer()
+                    ..onTap = () async {
+                      final url = Uri.parse('https://console.mistral.ai/');
+                      if (!await launchUrl(url)) {
+                        if (!context.mounted) return;
+                        context.showMessageSnackBar('Could not launch $url');
+                      }
+                    },
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 16),
+          ElevatedButton(
+            onPressed: () => const AppSettingsRoute().go(context),
+            child: const Text('Go to App Settings'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
 class MistralExampleTilesGrid extends StatelessWidget {
-  const MistralExampleTilesGrid({super.key});
+  const MistralExampleTilesGrid({required this.isEnabled, super.key});
+
+  final bool isEnabled;
 
   @override
   Widget build(BuildContext context) {
@@ -74,11 +125,11 @@ class MistralExampleTilesGrid extends StatelessWidget {
       crossAxisCount: columnSize,
       shrinkWrap: true,
       childAspectRatio: 1.75,
-      children: const <Widget>[
-        ChatExampleTile(),
-        TextSummaryTile(),
-        LllAsControllerTile(),
-        BookSearchTile(),
+      children: <Widget>[
+        ChatExampleTile(isEnabled: isEnabled),
+        TextSummaryTile(isEnabled: isEnabled),
+        LllAsControllerTile(isEnabled: isEnabled),
+        BookSearchTile(isEnabled: isEnabled),
       ],
     );
   }

--- a/lib/app/home_page.dart
+++ b/lib/app/home_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_ai_examples/app/app_settings/app_settings.dart';
 import 'package:flutter_ai_examples/app/home_tiles.dart';
 import 'package:flutter_ai_examples/app/router.dart';
+import 'package:provider/provider.dart';
 
 class HomePage extends StatelessWidget {
   const HomePage({super.key});
@@ -18,16 +20,39 @@ class HomePage extends StatelessWidget {
         body: const SafeArea(
           child: SingleChildScrollView(
             padding: EdgeInsets.all(20),
-            child: Column(
-              children: [
-                HomeSectionTitle(sectionTitle: 'Mistral AI Examples'),
-                SizedBox(height: 16),
-                MistralExampleTilesGrid(),
-              ],
-            ),
+            child: MistralAIExamples(),
           ),
         ),
       );
+}
+
+class MistralAIExamples extends StatelessWidget {
+  const MistralAIExamples({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isMistralSetUp = context.select<AppSettings, bool>(
+      (appSettings) => appSettings.value.isMistralApiKeyValid(),
+    );
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const HomeSectionTitle(sectionTitle: 'Mistral AI Examples'),
+        const SizedBox(height: 16),
+        if (isMistralSetUp) const MistralExampleTilesGrid(),
+        if (!isMistralSetUp)
+          const Align(
+            alignment: Alignment.centerLeft,
+            child: Text(
+              'Please set up the Mistral AI API key in the app settings.',
+              style: TextStyle(fontSize: 20),
+            ),
+          ),
+      ],
+    );
+  }
 }
 
 class MistralExampleTilesGrid extends StatelessWidget {

--- a/lib/app/home_tiles.dart
+++ b/lib/app/home_tiles.dart
@@ -4,8 +4,11 @@ import 'package:material_symbols_icons/material_symbols_icons.dart';
 
 class LllAsControllerTile extends StatelessWidget {
   const LllAsControllerTile({
+    required this.isEnabled,
     super.key,
   });
+
+  final bool isEnabled;
 
   @override
   Widget build(BuildContext context) {
@@ -16,6 +19,7 @@ class LllAsControllerTile extends StatelessWidget {
         Colors.red,
         Colors.orangeAccent,
       ],
+      isEnabled: isEnabled,
       onTap: () => const MistralAILlmControllerRoute().go(context),
     );
   }
@@ -23,8 +27,11 @@ class LllAsControllerTile extends StatelessWidget {
 
 class TextSummaryTile extends StatelessWidget {
   const TextSummaryTile({
+    required this.isEnabled,
     super.key,
   });
+
+  final bool isEnabled;
 
   @override
   Widget build(BuildContext context) {
@@ -35,6 +42,7 @@ class TextSummaryTile extends StatelessWidget {
         Colors.green,
         Colors.yellow,
       ],
+      isEnabled: isEnabled,
       onTap: () => const MistralAISummaryRoute().go(context),
     );
   }
@@ -42,8 +50,11 @@ class TextSummaryTile extends StatelessWidget {
 
 class ChatExampleTile extends StatelessWidget {
   const ChatExampleTile({
+    required this.isEnabled,
     super.key,
   });
+
+  final bool isEnabled;
 
   @override
   Widget build(BuildContext context) {
@@ -54,15 +65,19 @@ class ChatExampleTile extends StatelessWidget {
         Colors.blue[800]!,
         Colors.blue[400]!,
       ],
-      onTap: () => const MistralAIChatRoute().go(context),
+      isEnabled: isEnabled,
+      onTap: isEnabled ? () => const MistralAIChatRoute().go(context) : null,
     );
   }
 }
 
 class BookSearchTile extends StatelessWidget {
   const BookSearchTile({
+    required this.isEnabled,
     super.key,
   });
+
+  final bool isEnabled;
 
   @override
   Widget build(BuildContext context) {
@@ -73,6 +88,7 @@ class BookSearchTile extends StatelessWidget {
         Colors.purple,
         Colors.pinkAccent,
       ],
+      isEnabled: isEnabled,
       onTap: () => const MistralAIBookSearchRoute().go(context),
     );
   }
@@ -106,6 +122,8 @@ class HomeExampleTile extends StatelessWidget {
     required this.icon,
     required this.onTap,
     required this.gradientColors,
+    this.disabledGradientColors = const [Colors.grey, Colors.black54],
+    this.isEnabled = true,
     super.key,
   }) : assert(
           gradientColors.length == 2,
@@ -114,43 +132,48 @@ class HomeExampleTile extends StatelessWidget {
 
   final String title;
   final IconData icon;
-  final VoidCallback onTap;
+  final VoidCallback? onTap;
   final List<Color> gradientColors;
+  final List<Color> disabledGradientColors;
+  final bool isEnabled;
 
   @override
   Widget build(BuildContext context) {
     return InkWell(
-      onTap: onTap,
+      onTap: isEnabled ? onTap : null,
       borderRadius: BorderRadius.circular(8),
-      child: Ink(
-        padding: const EdgeInsets.all(12),
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(8),
-          gradient: LinearGradient(
-            begin: Alignment.bottomLeft,
-            end: Alignment.topRight,
-            colors: gradientColors,
-            stops: const [0.2806, 0.984],
+      child: Opacity(
+        opacity: isEnabled ? 1 : 0.7,
+        child: Ink(
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(8),
+            gradient: LinearGradient(
+              begin: Alignment.bottomLeft,
+              end: Alignment.topRight,
+              colors: isEnabled ? gradientColors : disabledGradientColors,
+              stops: const [0.2806, 0.984],
+            ),
           ),
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            Icon(
-              icon,
-              color: Colors.white,
-              size: 32,
-            ),
-            const SizedBox(height: 16),
-            Flexible(
-              child: Text(
-                title,
-                style: const TextStyle(color: Colors.white),
-                overflow: TextOverflow.ellipsis,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Icon(
+                icon,
+                color: Colors.white,
+                size: 32,
               ),
-            ),
-          ],
+              const SizedBox(height: 16),
+              Flexible(
+                child: Text(
+                  title,
+                  style: const TextStyle(color: Colors.white),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/mistral_ai_book_search_example/mistralai_book_search_page.dart
+++ b/lib/mistral_ai_book_search_example/mistralai_book_search_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_ai_examples/mistral_ai_book_search_example/book_search.dart';
 import 'package:flutter_ai_examples/mistral_ai_book_search_example/models.dart';
 import 'package:flutter_ai_examples/mistral_tokenizer/mistral_tokenizer.dart';
+import 'package:flutter_ai_examples/utils/snackbar_extension.dart';
 import 'package:provider/provider.dart';
 
 class MistralAIBookSearchPage extends StatelessWidget {
@@ -108,7 +109,7 @@ class _SearchFormState extends State<SearchForm> {
               hintText: 'Ask question about book...',
               prefixIcon: Icon(Icons.search),
             ),
-            onSubmitted: search,
+            onSubmitted: (value) => search(context, value),
           ),
         ),
         const SizedBox(height: 16),
@@ -155,7 +156,7 @@ class _SearchFormState extends State<SearchForm> {
     );
   }
 
-  void search(String question) {
+  void search(BuildContext context, String question) {
     debugPrint('Searching for $question');
     setState(() {
       result = null;
@@ -178,6 +179,11 @@ class _SearchFormState extends State<SearchForm> {
         setState(() {
           isSearching = false;
         });
+
+        context.showMessageSnackBar(
+          'There was a problem when trying to search for answer. '
+          'Please try again.',
+        );
       },
     );
   }

--- a/lib/mistral_ai_book_search_example/mistralai_book_search_page.dart
+++ b/lib/mistral_ai_book_search_example/mistralai_book_search_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_ai_examples/mistral_ai_book_search_example/book_search.dart';
 import 'package:flutter_ai_examples/mistral_ai_book_search_example/models.dart';
 import 'package:flutter_ai_examples/mistral_tokenizer/mistral_tokenizer.dart';
+import 'package:flutter_ai_examples/utils/error_message.dart';
 import 'package:flutter_ai_examples/utils/snackbar_extension.dart';
 import 'package:provider/provider.dart';
 
@@ -180,10 +181,7 @@ class _SearchFormState extends State<SearchForm> {
           isSearching = false;
         });
 
-        context.showMessageSnackBar(
-          'There was a problem when trying to search for answer. '
-          'Please try again.',
-        );
+        context.showMessageSnackBar(getNiceErrorMessage(error));
       },
     );
   }

--- a/lib/mistral_ai_chat_example/chat_model.dart
+++ b/lib/mistral_ai_chat_example/chat_model.dart
@@ -38,6 +38,7 @@ class _ChatModel extends ChangeNotifier {
       return;
     }
     _isGenerationInProgress = true;
+    error = null;
     _chatHistory.addLast(item);
     // notify ui about added user's message and updating loading state
     notifyListeners();
@@ -125,8 +126,6 @@ class _ChatModel extends ChangeNotifier {
   void _setError(String error) {
     this.error = error;
     notifyListeners();
-    // clear it to not show it again on rebuild
-    this.error = null;
   }
 
   @override

--- a/lib/mistral_ai_chat_example/chat_model.dart
+++ b/lib/mistral_ai_chat_example/chat_model.dart
@@ -112,8 +112,9 @@ class _ChatModel extends ChangeNotifier {
   }
 
   void _handleError(dynamic error) {
-    debugPrint('Error: $error');
-    _setError('Something went wrong. Please try again.');
+    final errorText = error.toString();
+    debugPrint('Error: $errorText');
+    _setError(getNiceErrorMessage(error));
   }
 
   void _generationDone() {

--- a/lib/mistral_ai_chat_example/mistralai_chat_page.dart
+++ b/lib/mistral_ai_chat_example/mistralai_chat_page.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:collection';
+import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:mistralai_client_dart/mistralai_client_dart.dart';
@@ -136,12 +137,14 @@ class _ChatMessageInputState extends State<_ChatMessageInput> {
     final showLoading = context.select(
       (_ChatModel model) => model.waitingForResponse,
     );
+    final error = context.select((_ChatModel model) => model.error);
     return TextField(
       focusNode: focusNode,
       textInputAction: TextInputAction.send,
       controller: messageController,
       decoration: InputDecoration(
         hintText: 'Type your message here...',
+        errorText: error,
         suffixIcon: showLoading
             ? const _TextFieldProgressIndicator()
             : IconButton(

--- a/lib/mistral_ai_chat_example/mistralai_chat_page.dart
+++ b/lib/mistral_ai_chat_example/mistralai_chat_page.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 import 'dart:collection';
-import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_ai_examples/utils/error_message.dart';
 import 'package:mistralai_client_dart/mistralai_client_dart.dart';
 import 'package:provider/provider.dart';
 

--- a/lib/mistral_ai_llm_controller_example/mistral_ai_llm_controller_page.dart
+++ b/lib/mistral_ai_llm_controller_example/mistral_ai_llm_controller_page.dart
@@ -6,6 +6,7 @@ import 'package:flutter_ai_examples/mistral_ai_llm_controller_example/logger_dia
 import 'package:flutter_ai_examples/mistral_ai_llm_controller_example/model.dart';
 import 'package:flutter_ai_examples/mistral_ai_llm_controller_example/prompt.dart';
 import 'package:flutter_ai_examples/mistral_ai_llm_controller_example/utils.dart';
+import 'package:flutter_ai_examples/utils/error_message.dart';
 import 'package:mistralai_client_dart/mistralai_client_dart.dart';
 import 'package:provider/provider.dart';
 
@@ -124,7 +125,9 @@ class _MistralAiLlmControllerPageState
       );
       _mapCommandResponseToUi(commandResult);
     } catch (e) {
-      setState(() => errorMessage = e.toString());
+      setState(() => errorMessage = getNiceErrorMessage(e));
+    } finally {
+      setState(() => showLoading = false);
     }
   }
 
@@ -286,11 +289,15 @@ class LlmControllerErrorTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      Scrollable.ensureVisible(
+        context,
+        duration: const Duration(milliseconds: 300),
+      );
+    });
     return ListTile(
-      title: Text(
-        'Error message: $errorMessage',
-        style: const TextStyle(color: Colors.red),
-      ),
+      titleTextStyle: const TextStyle(color: Colors.red),
+      title: Text(errorMessage),
     );
   }
 }

--- a/lib/mistral_ai_summary_example/mistralai_summary_page.dart
+++ b/lib/mistral_ai_summary_example/mistralai_summary_page.dart
@@ -3,6 +3,8 @@ import 'package:flutter/services.dart';
 import 'package:flutter_ai_examples/mistral_ai_summary_example/settings_model.dart';
 import 'package:flutter_ai_examples/mistral_ai_summary_example/summary_settings_page.dart';
 import 'package:flutter_ai_examples/mistral_ai_summary_example/utils.dart';
+import 'package:flutter_ai_examples/utils/error_message.dart';
+import 'package:flutter_ai_examples/utils/snackbar_extension.dart';
 import 'package:mistralai_client_dart/mistralai_client_dart.dart';
 import 'package:provider/provider.dart';
 
@@ -25,9 +27,12 @@ class _MistralAISummaryPageState extends State<MistralAISummaryPage> {
     super.dispose();
   }
 
-  Future<void> summarizeText(String text, SummarySettings settings) async {
+  Future<void> summarizeText(
+    BuildContext context,
+    String text,
+    SummarySettings settings,
+  ) async {
     setState(() => summaryInProgress = true);
-
     try {
       final response = await context.read<MistralAIClient>().chat(
             ChatParams(
@@ -49,13 +54,11 @@ class _MistralAISummaryPageState extends State<MistralAISummaryPage> {
         summaryResult = response.choices.first.message.content;
       });
     } catch (e) {
-      setState(() {
-        summaryResult = 'Error: $e';
-      });
+      debugPrint('$e');
+      if (!context.mounted) return;
+      context.showMessageSnackBar(getNiceErrorMessage(e));
     } finally {
-      setState(() {
-        summaryInProgress = false;
-      });
+      setState(() => summaryInProgress = false);
     }
   }
 
@@ -82,6 +85,7 @@ class _MistralAISummaryPageState extends State<MistralAISummaryPage> {
                   const SizedBox(height: 20),
                   SummaryActions(
                     onSummarize: () => summarizeText(
+                      context,
                       summaryInputController.text,
                       context.read<SummarySettingsModel>().settings,
                     ),

--- a/lib/utils/error_message.dart
+++ b/lib/utils/error_message.dart
@@ -1,0 +1,13 @@
+import 'package:mistralai_client_dart/mistralai_client_dart.dart';
+
+String getNiceErrorMessage(dynamic error) {
+  final errorText = error.toString();
+  if (error is MistralAIClientException) {
+    final isUnauthorized = errorText.contains('401');
+    return isUnauthorized
+        ? 'Unauthorized. Please check your API key.'
+        : 'Something went wrong when sending a request to Mistral API. '
+            'Please try again.\n($errorText)';
+  }
+  return 'Something went wrong. Please try again.\n($errorText)';
+}

--- a/lib/utils/snackbar_extension.dart
+++ b/lib/utils/snackbar_extension.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+extension SnackBarExtension on BuildContext {
+  void showMessageSnackBar(String message) {
+    final context = this;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        // limit the width of the snackbar to 500 if the screen is wider
+        width: MediaQuery.of(context).size.width > 500 ? 460 : null,
+        behavior: SnackBarBehavior.floating,
+        content: Text(message),
+      ),
+    );
+  }
+}

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,10 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,8 +7,10 @@ import Foundation
 
 import path_provider_foundation
 import shared_preferences_foundation
+import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
+  UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -6,11 +6,14 @@ PODS:
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
+  - url_launcher_macos (0.0.1):
+    - FlutterMacOS
 
 DEPENDENCIES:
   - FlutterMacOS (from `Flutter/ephemeral`)
   - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
   - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
+  - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
 
 EXTERNAL SOURCES:
   FlutterMacOS:
@@ -19,12 +22,15 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin
   shared_preferences_foundation:
     :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin
+  url_launcher_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
 
 SPEC CHECKSUMS:
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
   path_provider_foundation: 3784922295ac71e43754bd15e0653ccfd36a147c
   shared_preferences_foundation: b4c3b4cddf1c21f02770737f147a3f5da9d39695
+  url_launcher_macos: d2691c7dd33ed713bf3544850a623080ec693d95
 
 PODFILE CHECKSUM: 236401fc2c932af29a9fcf0e97baeeb2d750d367
 
-COCOAPODS: 1.14.2
+COCOAPODS: 1.11.3

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -829,6 +829,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: c512655380d241a337521703af62d2c122bf7b77a46ff7dd750092aa9433499c
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.2.4"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "507dc655b1d9cb5ebc756032eb785f114e415f91557b73bf60b7e201dfedeb2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.2.2"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "75bb6fe3f60070407704282a2d295630cab232991eb52542b18347a8a941df03"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.2.4"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: ab360eb661f8879369acac07b6bb3ff09d9471155357da8443fd5d3cf7363811
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.1"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: b7244901ea3cf489c5335bdacda07264a6e960b1c1b1a9f91e4bc371d9e68234
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: a932c3a8082e118f80a475ce692fde89dc20fddb24c57360b96bc56f7035de1f
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.1"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: fff0932192afeedf63cdd50ecbb1bc825d31aed259f02bb8dba0f3b729a5e88b
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.3"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: ecf9725510600aa2bb6d7ddabe16357691b6d2805f66216a97d1b881e21beff7
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.1"
   uuid:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   mistralai_client_dart: 0.0.2
   provider: ^6.1.1
   shared_preferences: ^2.2.2
+  url_launcher: ^6.2.4
   
 dev_dependencies:
   build_runner: ^2.4.8

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,9 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  UrlLauncherWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
- show missing mistral api key on home page
  - allow user to easily navigate to settings
  - guide user where he/she can get api key
  - grey out and make unclickable the example tiles
- all examples now are using unified error messaging
- when error happens:
  - show snackbar with error in book search example
  - show snackbar with error in text summary example
  - show error text below input in chat example
  - autoscroll to error in llm as controller example


<img width="391" alt="image" src="https://github.com/nomtek/flutter_ai_examples/assets/2642942/6f625f12-b635-4510-91d4-5898c8715425">

chat example error handling
<img width="391" alt="image" src="https://github.com/nomtek/flutter_ai_examples/assets/2642942/809e8b7e-60a1-442d-959e-97487c48738a">

summary example error handling
<img width="389" alt="image" src="https://github.com/nomtek/flutter_ai_examples/assets/2642942/3d741bcd-fdca-4b9b-8b94-aa6d2a52b6c1">

llm as controller example error handling
<img width="392" alt="image" src="https://github.com/nomtek/flutter_ai_examples/assets/2642942/a21272c0-e602-4379-be2f-914f66869873">

book search example error handling
<img width="392" alt="image" src="https://github.com/nomtek/flutter_ai_examples/assets/2642942/d5f2f4c2-89a0-4c8b-9303-bd8cd4bffa8e">

